### PR TITLE
run bundle update to get rid of circular argument reference error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,25 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (4.0.3)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    atomic (1.1.14)
-    i18n (0.6.9)
+    activesupport (5.1.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     jira-ruby (0.1.17)
       activesupport
-      oauth
-    minitest (4.7.5)
-    multi_json (1.8.4)
+      oauth (~> 0.4.7)
+    minitest (5.11.3)
     oauth (0.4.7)
     pasteboard (1.0)
     rb-scpt (1.0.2)
     terminal-notifier (1.5.1)
-    thread_safe (0.1.3)
-      atomic
-    tzinfo (0.3.38)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Updating activesupport to get rid of the annoying circular reference warning.