### PR TITLE
Changed the wrapper to uses strings instead of symbols.

### DIFF
--- a/lib/jira_wrapper.rb
+++ b/lib/jira_wrapper.rb
@@ -26,7 +26,7 @@ module JIRA
 
       client_options[:site]     = @base_url
       
-      if config["jira_client"]["auth_type"] == :basic
+      if config["jira_client"]["auth_type"] == "basic"
         client_options[:auth_type] = :basic
         client_options[:username] = config["jira_client"]["username"]                                     or raise "jira_client['username'] not set in config"
         client_options[:password] = self.class.get_password(@app_name, config["jira_client"]["username"]) or raise "jira_client['password'] not found / not accessible in keychain"


### PR DESCRIPTION
This matches what you get in the yaml file by default

Resolves #6 