### PR TITLE
add more helpful messages when the config file is not setup correctly

### DIFF
--- a/lib/glue.rb
+++ b/lib/glue.rb
@@ -12,6 +12,9 @@ class Glue
   
   def initialize(config)
     browser_name = (config["browser"] && config["browser"]["name"]) || "Google Chrome" # Optional with backwards compatibility
+
+    config && config["app"] or raise "config file is not setup correctly: it is missing the 'app' key. See README for setup instructions"
+
     @notifier = Notifier.new(config["app"]["name"], config["app"]["title"], browser_name)
     @jira     = JIRA::Wrapper.new(config, @notifier)
     @browser  = Browser.new(browser_name, @jira.base_url)
@@ -89,3 +92,4 @@ class Glue
     @notifier.show_message!(message)
   end
 end
+

--- a/lib/jira_wrapper.rb
+++ b/lib/jira_wrapper.rb
@@ -20,7 +20,8 @@ module JIRA
     def initialize(config, notifier, debug: false)
       client_options            = JIRA_CLIENT_OPTIONS.dup
             
-      @app_name                 = config["app"]["name"]
+      config && config["app"] && config["jira_client"]                                                  or raise "config file is not setup correctly: missing the 'app' and/or 'jira_client' key. See README for setup instructions"
+      @app_name                 = config["app"]["name"]                                                 or raise "app['name'] not set in config"
       @base_url                 = config["jira_client"]["base_url"]                                     or raise "jira_client['base_url'] not set in config"
       @notifier                 = notifier
 


### PR DESCRIPTION
Adding some more helpful error messages when the config file is not setup correctly. We recently ran into an issue with the config file not being setup, and the error message was an unhelpful 
```undefined method `[]' for nil:NilClass```