### PR TITLE
Add support for sub-tasks to the jira branch namer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,17 @@ The branch name would now have the following prefix:
 ```
 YYMM/STORY-123_jira_issue_description
 ```
+
+##### Sub-Task Support
+If the JIRA Issue provided is a sub-task, the branch name will include the parent issue key and description followed by the sub-task key and description.
+
+Given the following:
+* Jira Issue Number: STORY-123
+* Jira Issue Description: Fix Jira-glue bug
+* Sub-Task of STORY-123 Issue Number: STORY-124
+* Sub-Task of STORY-123 Issue Description: Add documentation
+
+```
+ruby ./branch_name.rb STORY-124
+STORY-123_fix_jira_glue_bug.STORY-124_add_documentation
+```

--- a/lib/glue.rb
+++ b/lib/glue.rb
@@ -9,7 +9,7 @@ require File.expand_path('../browser.rb',  __FILE__)
 
 class Glue
   attr_reader :jira
-  
+
   def initialize(config)
     browser_name = (config["browser"] && config["browser"]["name"]) || "Google Chrome" # Optional with backwards compatibility
 
@@ -90,15 +90,12 @@ class Glue
   end
 
   def build_branch_name_from_issue(issue, copy_to_clipboard = true)
-    issue or return
+    issue || return
 
-    summary, = @jira.issue_description_and_link_from_issue(issue)
-
-    # Formatting: downcase -> replace specific non-alphanumeric characters with spaces -> remove non-alphanumberic characters -> replace spaces with join
-    summary_formatted = summary.downcase.tr(':;()-.', ' ').gsub(/[^a-z0-9\s&]/, '').split(' ').join('_')
-    prefix            = @prefix_format ? "#{Time.new.strftime(@prefix_format)}/" : ''
-
-    branch_name       = "#{prefix}#{issue.key}_#{summary_formatted}"
+    summary        = formatted_summary(issue)
+    parent_summary = parent_summary(issue)
+    prefix         = @prefix_format ? "#{Time.new.strftime(@prefix_format)}/" : ''
+    branch_name    = "#{prefix}#{parent_summary}#{summary}"
 
     Clipboard.insert_text!(branch_name) if copy_to_clipboard
 
@@ -107,6 +104,26 @@ class Glue
 
   def display_notification(message)
     @notifier.show_message!(message)
+  end
+
+  private
+
+  def formatted_summary(issue)
+    issue_description, = @jira.issue_description_and_link_from_issue(issue)
+
+    # Formatting: downcase -> replace specific non-alphanumeric characters with spaces -> remove non-alphanumberic characters -> replace spaces with join
+    formatted_issue_description = issue_description.downcase.tr(':;()-.', ' ').gsub(/[^a-z0-9\s&]/, '').split(' ').join('_')
+
+    "#{issue.key}_#{formatted_issue_description}"
+  end
+
+  def parent_summary(issue)
+    if issue.issuetype.name == 'Sub-task'
+      parent_issue = @jira.find_issue(issue.parent['key'])
+      "#{formatted_summary(parent_issue)}."
+    else
+      ''
+    end
   end
 end
 


### PR DESCRIPTION
Adding support for naming branches for sub-tasks, according to our naming conventions. 

@nburwell, let me know if you think this is too Invoca-specific for this repo. I do not know how others handle branch names for JIRA subtasks, but the general idea of including the parent issue key seems to be logical.